### PR TITLE
FIX: Issue 68 - cache=none disks are ignored

### DIFF
--- a/eve4pve-barc
+++ b/eve4pve-barc
@@ -566,7 +566,7 @@ function get_disks_from_config(){
                 echo "$line"
             done < "$file_config" | \
             grep -P '^(?:((?:virtio|ide|scsi|sata|mp|efidisk)\d+)|rootfs): ' | \
-            grep -v -P 'cdrom|none' | \
+            grep -v -P '^(?!.*cloudinit).*media=cdrom.*$' | \
             grep -v -P 'backup=0' | \
             awk '{ split($0,a,","); split(a[1],b," "); print b[2]}')
 


### PR DESCRIPTION
Excludes all cdrom entries, while allowing cloudinit based images to also be backed up.